### PR TITLE
✨ Feat: signup page UI

### DIFF
--- a/src/components/common/input/emailInput/index.tsx
+++ b/src/components/common/input/emailInput/index.tsx
@@ -1,6 +1,6 @@
 import { FieldError, UseFormClearErrors, UseFormRegisterReturn } from 'react-hook-form';
 
-interface InputForm {
+interface EmailInputForm {
   email: string;
   password: string;
 }
@@ -11,7 +11,7 @@ interface InputProps {
   type: 'email' | 'password';
   register: UseFormRegisterReturn;
   error: FieldError;
-  clearError: UseFormClearErrors<InputForm>;
+  clearError: UseFormClearErrors<EmailInputForm>;
 }
 
 const EmailInput = ({ register, inputName, inputContent, labelId, error, clearError }: InputProps) => {

--- a/src/components/common/input/index.tsx
+++ b/src/components/common/input/index.tsx
@@ -1,0 +1,59 @@
+import { FieldError, UseFormClearErrors, UseFormRegisterReturn } from 'react-hook-form';
+import { twMerge } from 'tailwind-merge';
+
+interface InputForm {
+  text?: string;
+  email?: string;
+  password?: string;
+  passwordcheck?: string;
+}
+interface InputProps {
+  inputName: string;
+  inputContent: string;
+  labelId: string;
+  labelText: string;
+  type: any;
+  register: UseFormRegisterReturn;
+  error?: FieldError;
+  clearError?: UseFormClearErrors<InputForm>;
+  divCheckStyly?: string;
+  inputCheckStyle?: string;
+}
+
+const Input = ({
+  register,
+  inputName,
+  inputContent,
+  labelId,
+  labelText,
+  type,
+  error,
+  clearError,
+  divCheckStyly,
+  inputCheckStyle,
+}: InputProps) => {
+  const divStyle = twMerge(`flex flex-col items-start py-8 text-gray-9f text-16`, divCheckStyly);
+  const inputStyle = twMerge(
+    'w-full h-50 py-15 px-16 border-1 rounded-lg border-gray-9f text-black-33 focus:outline-none  focus:border-violet',
+    inputCheckStyle,
+  );
+  return (
+    <div className={divStyle}>
+      <label className="text-black-33" htmlFor={labelId}>
+        {labelText}
+      </label>
+      <input
+        {...register}
+        type={type}
+        name={inputName}
+        className={error?.message ? 'w-full h-50 py-15 px-16 border-1 rounded-lg border-red text-black-33' : inputStyle}
+        placeholder={inputContent}
+        id={labelId}
+        onFocus={() => (clearError ? clearError(['text', 'email', 'password']) : '')}
+      />
+      {error?.message && <div className="text-red text-14">{error.message}</div>}
+    </div>
+  );
+};
+
+export default Input;

--- a/src/components/common/input/passwordInput/index.tsx
+++ b/src/components/common/input/passwordInput/index.tsx
@@ -4,21 +4,23 @@ import eyeOn from '@/public/assets/icon/eyeOn.svg';
 import { FieldError, UseFormClearErrors, UseFormRegisterReturn } from 'react-hook-form';
 import { useState } from 'react';
 
-interface InputForm {
-  email: string;
-  password: string;
+interface PasswordInputForm {
+  email?: string;
+  password?: string;
+  passwordcheck?: string;
 }
 interface InputProps {
   inputName: string;
+  labelName: string;
   inputContent: string;
   labelId: string;
   type: 'email' | 'password';
   register: UseFormRegisterReturn;
   error: FieldError;
-  clearError: UseFormClearErrors<InputForm>;
+  clearError: UseFormClearErrors<PasswordInputForm>;
 }
 
-const PasswordInput = ({ register, inputName, inputContent, labelId, error, clearError }: InputProps) => {
+const PasswordInput = ({ register, inputName, inputContent, labelId, labelName, error, clearError }: InputProps) => {
   const [openEye, setOpenEye] = useState(false);
 
   const toggleEye = () => {
@@ -28,7 +30,7 @@ const PasswordInput = ({ register, inputName, inputContent, labelId, error, clea
   return (
     <div className="flex flex-col items-start py-8 text-gray-9f text-16">
       <label className="text-black-33" htmlFor="password">
-        비밀번호
+        {labelName}
       </label>
       <div
         className={
@@ -44,7 +46,7 @@ const PasswordInput = ({ register, inputName, inputContent, labelId, error, clea
           className={error?.message ? ' text-black-33' : ' text-black-33 '}
           placeholder={inputContent}
           id={labelId}
-          onFocus={() => clearError('password')}
+          onFocus={() => clearError(['password', 'passwordcheck'])}
         />
         <Image className="" onClick={toggleEye} src={openEye ? eyeOn : eyeOff} alt={openEye ? 'eyeOn' : 'eyeOff'} />
       </div>

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -8,6 +8,7 @@ import { FieldError, useForm } from 'react-hook-form';
 interface InputForm {
   email: string;
   password: string;
+  passwordcheck?: string;
 }
 
 const Signin = () => {
@@ -55,7 +56,6 @@ const Signin = () => {
               />
             </form>
             <form onSubmit={handleSubmit(onSubmit)}>
-              {' '}
               {/* handleSubmit 함수를 onSubmit 이벤트 핸들러로 설정 */}
               <PasswordInput
                 register={register('password', {
@@ -74,6 +74,7 @@ const Signin = () => {
                 inputName="password"
                 inputContent="비밀번호를 입력해 주세요"
                 labelId="password"
+                labelName="비밀번호"
               />
             </form>
           </div>
@@ -89,10 +90,9 @@ const Signin = () => {
         </main>
         <footer>
           <p>
-            회원이 아니신가요?{' '}
-            <a className="underline text-violet" href="/signup">
-              회원가입하기
-            </a>
+            회원이 아니신가요?
+            {/* prettier-ignore */}
+            <a className="underline text-violet" href="/signup">  회원가입하기</a>
           </p>
         </footer>
       </div>

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,0 +1,154 @@
+import Image from 'next/image';
+import mainLogo from '@/public/assets/logo/mainLogo.svg';
+import EmailInput from '@/src/components/common/input/emailInput';
+import PasswordInput from '@/src/components/common/input/passwordInput';
+import Button from '@/src/components/common/button';
+import { FieldError, useForm } from 'react-hook-form';
+import Input from '@/src/components/common/input';
+
+interface InputForm {
+  text: string;
+  email: string;
+  password: string;
+  passwordcheck: string;
+  checkbox: boolean;
+}
+
+const Signup = () => {
+  const {
+    register,
+    handleSubmit, // handleSubmit 추가
+    formState: { errors },
+    clearErrors,
+    getValues,
+  } = useForm<InputForm>({ mode: 'onBlur', reValidateMode: 'onBlur' });
+
+  const onSubmit = (data: InputForm) => {
+    // 폼 제출 시 실행되는 함수
+    console.log(data); // 입력된 데이터 확인용
+  };
+
+  return (
+    <div>
+      <div className="h-screen flex flex-col justify-center items-center gap-24">
+        <header className="flex flex-col items-center gap-10">
+          <Image className="modile:w-120" src={mainLogo} alt="mainLogo" />
+          <h1 className="text-20 mb-6 font-medium">오늘도 만나서 반가워요!</h1>
+        </header>
+        <main className="w-520 mobile:w-351">
+          <div className="pb-16">
+            <form onSubmit={handleSubmit(onSubmit)}>
+              <EmailInput
+                register={register('email', {
+                  required: {
+                    value: true,
+                    message: '이메일 형식으로 작성해 주세요.',
+                  },
+                  pattern: {
+                    value: /^[^\s@]+@[^\s@]+\.[^\s@]+$/,
+                    message: '이메일 형식으로 작성해 주세요.',
+                  },
+                })}
+                type="email"
+                clearError={clearErrors}
+                error={errors.email as FieldError}
+                inputName="email"
+                inputContent="이메일을 입력해 주세요"
+                labelId="email"
+              />
+              <Input
+                register={register('text', {
+                  required: {
+                    value: true,
+                    message: '열 자 이하로 작성해주세요.',
+                  },
+                  pattern: {
+                    value: /^. {1,10}$/,
+                    message: '열 자 이하로 작성해주세요.',
+                  },
+                })}
+                type="text"
+                clearError={clearErrors}
+                error={errors.text as FieldError}
+                inputName="text"
+                inputContent="닉네임을 입력해 주세요"
+                labelId="text"
+                labelText="닉네임"
+              />
+              <PasswordInput
+                register={register('password', {
+                  required: {
+                    value: true,
+                    message: '8자 이상 입력해 주세요.',
+                  },
+                  pattern: {
+                    value: /^.{8,}$/,
+                    message: '8자 이상 입력해 주세요.',
+                  },
+                })}
+                type="password"
+                clearError={clearErrors}
+                error={errors.password as FieldError}
+                inputName="password"
+                inputContent="8자 이상 입력해 주세요"
+                labelId="password"
+                labelName="비밀번호"
+              />
+              <PasswordInput
+                register={register('passwordcheck', {
+                  required: {
+                    value: true,
+                    message: '비밀번호가 일치하지 않습니다.',
+                  },
+                  validate: {
+                    check: (val) => {
+                      if (getValues('password') !== val) {
+                        return '비밀번호가 일치하지 않습니다.';
+                      }
+                      return undefined;
+                    },
+                  },
+                })}
+                type="password"
+                clearError={clearErrors}
+                error={errors.passwordcheck as FieldError}
+                inputName="passwordcheck"
+                inputContent="비밀번호를 한번 더 입력해 주세요"
+                labelId="passwordcheck"
+                labelName="비밀번호 확인"
+              />
+              <Input
+                register={register('checkbox', {})}
+                type="checkbox"
+                inputName="checkbox"
+                inputContent=""
+                labelId="checkbox"
+                labelText="이용약관에 동의합니다."
+                divCheckStyly="flex-row-reverse justify-end items-center h-20 gap-8 py-20"
+                inputCheckStyle="w-20 h-20"
+              />
+            </form>
+          </div>
+          <Button
+            type="submit"
+            buttonType="login"
+            bgColor="violet"
+            textColor="white"
+            disabled={Object.keys(errors).length !== 0} // errors 객체가 비어있지 않으면 disabled로 설정
+          >
+            가입하기
+          </Button>
+        </main>
+        <footer>
+          <p>
+            이미 가입하셨나요?
+            {/* prettier-ignore */}
+            <a className="underline text-violet" href="/signin">  로그인하기</a>
+          </p>
+        </footer>
+      </div>
+    </div>
+  );
+};
+
+export default Signup;


### PR DESCRIPTION
## 작업 주제
- [x] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 구현 사항 설명
- 기존 email, password input말고 공통 input생성 => 로그인페이지, 회원가입페이지, 칼럼추가페이지, 칼럼관리페이지(추후?), 초대하기 모달창(추후?), 계정관리 페이지 에서 사용 가능
- 회원가입 페이지 구현 (email input + 기본 input + password input), checkbox
- 회원가입 페이지 반응형
- input에 error 기능 구현

## 스크린샷 or 배포링크
![스크린샷 2024-04-20 052836](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/ae9a7cfd-4680-44a6-b619-4d1e9e02a004)

![스크린샷 2024-04-20 052844](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/bc1f0606-ea77-4f9c-9d17-facbbd9763d5)

![스크린샷 2024-04-20 052851](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/b1981632-89ff-4930-a65e-7ec1a19a7c22)

![스크린샷 2024-04-20 052859](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/619e67fb-81cd-478d-ae18-53eb7ea90f29)

![스크린샷 2024-04-20 052828](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/9d2a774e-a272-4452-9aab-424bf37782c2)

## 성장포인트 & 보완할 점
- 기능 구현하면서 버튼 disable 더 자세히 구현
- 기본 input이 배열이라 초기화되는 문제점 발견 추후 수정
