### PR TITLE
✨ Feat: signup Page

### DIFF
--- a/src/components/common/input/passwordInput/index.tsx
+++ b/src/components/common/input/passwordInput/index.tsx
@@ -44,7 +44,7 @@ const PasswordInput = ({
   };
 
   const divStyle = twMerge(
-    `flex flex-row  justify-between w-full h-50 py-15 px-16 border-1 rounded-lg border-gray-9f focus:outline-none  focus:border-violet`,
+    `flex flex-row  justify-between w-full h-50 py-15 px-16 border-1 rounded-lg border-gray-9f focus:outline-none  focus-within:border-violet`,
     divCheckStyle,
   );
   const divErrorStyle = twMerge(
@@ -61,7 +61,7 @@ const PasswordInput = ({
           {...register}
           type={openEye ? 'text' : 'password'}
           name={inputName}
-          className={error?.message ? ' text-black-33' : ' text-black-33 '}
+          className="w-full text-black-33"
           placeholder={inputContent}
           id={labelId}
           onFocus={() => {

--- a/src/components/mypage/index.tsx
+++ b/src/components/mypage/index.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import add from '@/public/assets/icon/addViolet.svg';
-import DashboardCard from '../dashboardEdit/DashboardCard';
 import Button from '../common/button';
 import Input from '../common/input';
 import PasswordInput from '../common/input/passwordInput';
@@ -42,7 +41,7 @@ const MyPageContent = () => {
         <Image src={arrow} alt="go back" width={20} />
         <p className="font-semibold">돌아가기</p>
       </Link>
-      <DashboardCard>
+      <div className="w-620 rounded-8 bg-white px-28 py-32 flex flex-col gap-37 mobile:gap-24 tablet:w-full">
         <p className="font-bold text-20">프로필</p>
         <div className="flex items-center justify-center mobile:flex-col">
           <form>
@@ -116,8 +115,8 @@ const MyPageContent = () => {
             저장
           </Button>
         </div>
-      </DashboardCard>
-      <DashboardCard>
+      </div>
+      <div className="w-620 rounded-8 bg-white px-28 py-32 flex flex-col gap-37 mobile:gap-24 tablet:w-full">
         <p className="font-bold text-20">비밀번호 변경</p>
         <div className="flex m-auto">
           <form className="w-564 tablet:w-488 mobile:w-244" onSubmit={handleSubmit(onSubmit)}>
@@ -201,7 +200,7 @@ const MyPageContent = () => {
             변경
           </Button>
         </div>
-      </DashboardCard>
+      </div>
     </main>
   );
 };

--- a/src/pages/signin/index.tsx
+++ b/src/pages/signin/index.tsx
@@ -8,7 +8,7 @@ import Link from 'next/link';
 import postUser from '@/src/api/userApi';
 import { useRouter } from 'next/router';
 import SignModal from '@/src/components/common/signModal';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface InputForm {
   text?: string;
@@ -26,7 +26,6 @@ const Signin = () => {
     handleSubmit,
     formState: { errors },
     clearErrors,
-    getValues,
   } = useForm<InputForm>({ mode: 'onBlur', reValidateMode: 'onBlur' });
 
   const router = useRouter();
@@ -53,8 +52,11 @@ const Signin = () => {
     }
   };
 
-  const newEmailValue = getValues('email');
-  console.log(newEmailValue);
+  useEffect(() => {
+    if (window.localStorage.getItem('accessToken')) {
+      router.push('/my-dashboard');
+    }
+  });
 
   return (
     <div>
@@ -63,7 +65,7 @@ const Signin = () => {
           <Image className="modile:w-120" src={mainLogo} alt="mainLogo" />
           <h1 className="text-20 mb-6 font-medium">오늘도 만나서 반가워요!</h1>
         </header>
-        <main className="w-520 mobile:w-351">
+        <main>
           <form onSubmit={handleSubmit(onSubmit)}>
             <div className="pb-16">
               <Input
@@ -85,6 +87,7 @@ const Signin = () => {
                 labelId="email"
                 labelText="이메일"
                 focusType="email"
+                labelDropStyle="w-520 mobile:w-351"
               />
               <PasswordInput
                 register={register('password', {

--- a/src/util/axios.ts
+++ b/src/util/axios.ts
@@ -4,8 +4,7 @@ const instance = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/4-13/',
 });
 
-const token =
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MTk5MywidGVhbUlkIjoiNC0xMyIsImlhdCI6MTcxMzcxMzk0NiwiaXNzIjoic3AtdGFza2lmeSJ9.r2xKX_D4sv3R77JjPt--Wm9dGycyzusV6s9nnXtYz74';
+const token = window.localStorage.getItem('accessToken');
 
 instance.interceptors.request.use((config) => {
   const modifiedConfig = { ...config };

--- a/src/util/axios.ts
+++ b/src/util/axios.ts
@@ -4,11 +4,18 @@ const instance = axios.create({
   baseURL: 'https://sp-taskify-api.vercel.app/4-13/',
 });
 
-const token = window.localStorage.getItem('accessToken');
+const getToken = () => {
+  // 브라우저(윈도우객체)가 있을때만 실행
+  if (typeof window !== undefined) {
+    const token = window.localStorage.getItem('accessToken');
+    return token;
+  }
+  return '';
+};
 
 instance.interceptors.request.use((config) => {
   const modifiedConfig = { ...config };
-  modifiedConfig.headers.Authorization = `Bearer ${token}`;
+  modifiedConfig.headers.Authorization = `Bearer ${getToken}`;
   return modifiedConfig;
 });
 


### PR DESCRIPTION
## 작업 주제
- [x] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정

## 구현 사항 설명
- 회원가입 페이지 api연결
- 회원가입 성공시 모달창 열고 가입완료 메세지 띄우기
- 회원가입 성공시 /signin 으로 가도록 연결
- 회원가입 실패시 모달창 열고 에러 메세지 (이메일이 불일치하는 경우에만 모달로 뜨고 나머진 input에 이미 넣어둠)
- 로그인 페이지에 accessToken 만들었던거 공용으로 쓸 수 있도록 util/axios에 넣어둠(가짜 토큰 쓸 필요 없어짐)
- accessToken이 있을 경우 로그인이나 회원가입을 다시 하면 안되니깐 들어오지 못하고 my-dashboard로 가도록 처리
- input 컴포넌트 바꾸면서 바뀐 디테일한 input UI 수정
- 멘토링에서 로컬스토리지는 서버에서 못 쓰니깐, 견고하게 코드 짜기 구현 -> 브라우저에서만 쓸 수 있게

## 스크린샷 or 배포링크

![스크린샷 2024-04-24 024100](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/60bc96a3-16b0-4353-8bfe-9ecd8a9da445)


![스크린샷 2024-04-24 023959](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/f61dda4c-08b6-4212-9e7b-7946e0081171)

![스크린샷 2024-04-24 024035](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/bc12c8a8-c95e-4cc8-ae48-2d485028faba)



## 성장포인트 & 보완할 점
- accessToken이 만료기간이 있으니 이걸 로그아웃을 만들어서 관리해줄지, 리프레시 토큰을 쓸지 고민하면 좋을 듯
- 멘토링에서 알려줬던 이슈들(깜박 리다이렉트,  디바운스 등) 해보면 좋을 듯