### PR TITLE
✨ Feat: profileimg 수정+구현 

### DIFF
--- a/src/components/mypage/profile.tsx
+++ b/src/components/mypage/profile.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react';
 import { getMyPageProfile, postMyPageProfile, putMyPageProfile } from '@/src/pages/api/mypageApi';
 import Button from '../common/button';
 import Input from '../common/input';
+import SignModal from '../common/signModal';
 
 interface InputForm {
   text?: string;
@@ -35,6 +36,14 @@ const Profile = () => {
       return { email: response.email, text: response.nickname, file: response.profileImageUrl }; // 가져온 사용자 정보 확인용
     },
   });
+
+  const [open, setOpen] = useState(false);
+
+  const handleModal = () => {
+    // open이 true일때 모달이 열림
+    setOpen(!open);
+  };
+
   const imagefile = watch('file'); // watch를 통해서 input의 value를 가져옴 : 능동적으로 움직여야해서 getValue말고 watch를 씀
 
   // 이미지 미리보기(브라우저에 임시 전달)
@@ -47,6 +56,9 @@ const Profile = () => {
 
   // 버튼클릭시, 새 닉네임, 이미지 url 전달
   const onSubmit = async (data: InputForm) => {
+    if (temp === null || temp === '') {
+      handleModal();
+    }
     // 이미지 url전달(서버에 최종전달)
     if (data.file && data.file['length'] === 1) {
       // data.file 키로 0, length가 있는데, 0은 url이므로 판별이 어려움
@@ -61,6 +73,10 @@ const Profile = () => {
     }
   };
 
+  const handleBack = () => {
+    setTemp('');
+  };
+
   return (
     <div className="w-620 rounded-8 bg-white px-28 py-32 flex flex-col gap-37 mobile:gap-24 tablet:w-full">
       <p className="font-bold text-20">프로필</p>
@@ -73,13 +89,21 @@ const Profile = () => {
           labelId="file"
           focusType="file"
           divCheckStyle="flex items-center justify-center w-182 h-182 mr-16 py-0"
-          inputCheckStyle="hidden"
-          labelDropStyle="flex flex-col items-center justify-center w-182 h-182 border-2 bg-gray-fa border-dashed rounded-6 cursor-pointerdark:hover:bg-bray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600"
+          inputCheckStyle="hidden "
+          labelDropStyle="flex flex-col relative items-center justify-center w-182 h-182 border-2 bg-gray-fa border-dashed rounded-6 cursor-pointerdark:hover:bg-bray-800 dark:bg-gray-700 hover:bg-gray-100 dark:border-gray-600 dark:hover:border-gray-500 dark:hover:bg-gray-600"
         >
-          {temp === null ? (
+          {temp === null || temp === '' ? (
             <Image src={add} width={40} height={40} alt="add icon" />
           ) : (
-            <Image src={temp} width={202} height={202} className="overflow-hidden rounded-6" alt="profile image" />
+            <>
+              <Image src={temp} width={202} height={202} className="overflow-hidden rounded-6 " alt="profile image" />
+              <button
+                onClick={handleBack}
+                className="bg-violet w-25 h-25 border rounded-full text-white absolute -top-10 -left-10"
+              >
+                X
+              </button>
+            </>
           )}
         </Input>
         <div>
@@ -132,6 +156,7 @@ const Profile = () => {
           </div>
         </div>
       </form>
+      <SignModal errorText="이미지는 필수 요소입니다." openModal={open} handleModalClose={handleModal} />
     </div>
   );
 };

--- a/src/components/mypage/profile.tsx
+++ b/src/components/mypage/profile.tsx
@@ -48,14 +48,17 @@ const Profile = () => {
   // 버튼클릭시, 새 닉네임, 이미지 url 전달
   const onSubmit = async (data: InputForm) => {
     // 이미지 url전달(서버에 최종전달)
-    const formdata = new FormData();
-    if (data.file) {
+    if (data.file && data.file['length'] === 1) {
+      // data.file 키로 0, length가 있는데, 0은 url이므로 판별이 어려움
+      const formdata = new FormData();
       formdata.append('image', data.file[0]);
+      const response = await postMyPageProfile(formdata);
+      const putdata = { nickname: data.text, profileImageUrl: response.profileImageUrl };
+      putMyPageProfile(putdata);
+    } else {
+      const putdata = { nickname: data.text, profileImageUrl: data.file ? data.file : '' }; // nickname만 필요하지만 put은 전체 데이터를 요구
+      putMyPageProfile(putdata);
     }
-    const response = await postMyPageProfile(formdata);
-    const putdata = { nickname: data.text, profileImageUrl: response.profileImageUrl };
-    putMyPageProfile(putdata);
-    // 새 닉네임 , 새 url 전달
   };
 
   return (

--- a/src/pages/api/mypageApi.ts
+++ b/src/pages/api/mypageApi.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 
 interface profileProps {
   nickname: string | undefined;
-  profileImageUrl: string;
+  profileImageUrl?: string;
 }
 
 interface passwordCheckProps {
@@ -23,7 +23,7 @@ export const getMyPageProfile = async () => {
 
 export const postMyPageProfile = async (data: FormData) => {
   try {
-    const response = await instance.post(`users/me/image`, data);
+    const response = await instance.post('users/me/image', data);
     return response.data;
   } catch (error) {
     console.log(error);


### PR DESCRIPTION
## 작업 주제
- [x] UI추가
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정

## 구현 사항 설명
- mypage profile에서 서버로 닉네임이랑 사진 url을 넘겨줘야하는데, 사진 없이 닉네임만 보냈을때 서버 오류 발생한거 수정
- 사진 미리보기(브라우저 url) 삭제하는 기능 구현
- nav의 초기 프로필 이미지는 nav자체적인거라 건들지 못하고, 서버에서의 초기값은 null이지만 profileImageUrl에 null을 적는건 api에서 받아주지 않으므로 미리보기에서만 사진이 안보이도록 구현하고 만약 미리보기에서 이미지를 삭제하고 저장 버튼을 누르면 금지시키고 경고하는 모달창 구현

## 스크린샷 or 배포링크

![스크린샷 2024-04-26 215004](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/b9538b0a-613d-4608-aec8-055b54c3adcb)

![스크린샷 2024-04-26 224101](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/87994513-3c17-4d23-a010-b57f6868aad2)

![스크린샷 2024-04-26 225312](https://github.com/Part3-Team13-Taskify/Taskify/assets/129635857/3c338b5a-78c2-492b-a584-dce1603b1a8f)

## 성장포인트 & 보완할 점
- 판별하는 과정에서 data.file의 키값이 0, length가 있는데, 0은 url을 받아와서 변별력이 없음. 그래서 키인 length를 사용했는데 eslint에서 length를 .length로 인식해서 es오류가 발생. 추후 정규표현식이나 다른 방법을 고려해 볼 예정
